### PR TITLE
Fix assetsPolicyById response schema

### DIFF
--- a/src/endpoints/api/assets/index.ts
+++ b/src/endpoints/api/assets/index.ts
@@ -147,7 +147,7 @@ export async function assetsPolicyById(
   this: BlockFrostAPI,
   policy: string,
   pagination?: PaginationOptions,
-): Promise<components['schemas']['asset_addresses']> {
+): Promise<components['schemas']['asset_policy']> {
   const paginationOptions = getPaginationOptions(pagination);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Response schema for assetsPolicyById should be:
```
{
  asset,
  quantity
}
```

Ref: https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1{asset}~1addresses/get