### PR TITLE
chore: always throw SignatureVerificationError on invalid signature

### DIFF
--- a/test/fixtures/utils/helpers.ts
+++ b/test/fixtures/utils/helpers.ts
@@ -1,4 +1,6 @@
-export const verifyWebhookSignatureErrorFixtures = [
+import { SignatureVerificationError } from '../../../src/utils/errors';
+
+export const verifyWebhookSignatureFixtures = [
   {
     description: 'invalid signatureHeader, missing "t" key',
     webhookPayload:
@@ -8,7 +10,7 @@ export const verifyWebhookSignatureErrorFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 1,
-    result: false,
+    result: SignatureVerificationError,
   },
   {
     description: 'invalid signatureHeader, missing version key',
@@ -18,7 +20,7 @@ export const verifyWebhookSignatureErrorFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 1,
-    result: false,
+    result: SignatureVerificationError,
   },
   {
     description: 'invalid signatureHeader, passed array as signatureHeader',
@@ -31,10 +33,8 @@ export const verifyWebhookSignatureErrorFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 1,
-    result: false,
+    result: SignatureVerificationError,
   },
-];
-export const verifyWebhookSignatureFixtures = [
   {
     description: 'invalid timestamp',
     webhookPayload:
@@ -44,7 +44,7 @@ export const verifyWebhookSignatureFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: undefined,
-    result: false,
+    result: SignatureVerificationError,
   },
   {
     description: 'valid timestamp (+1s)',
@@ -56,6 +56,17 @@ export const verifyWebhookSignatureFixtures = [
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 1,
     result: true,
+  },
+  {
+    description: 'only unsupported sig version',
+    webhookPayload:
+      '{"id":"47668401-c3a4-42d4-bac1-ad46515924a3","webhook_id":"cf68eb9c-635f-415e-a5a8-6233638f28d7","created":1650013856,"type":"block","payload":{"time":1650013853,"height":7126256,"hash":"f49521b67b440e5030adf124aee8f88881b7682ba07acf06c2781405b0f806a4","slot":58447562,"epoch":332,"epoch_slot":386762,"slot_leader":"pool1njjr0zn7uvydjy8067nprgwlyxqnznp9wgllfnag24nycgkda25","size":34617,"tx_count":13,"output":"13403118309871","fees":"4986390","block_vrf":"vrf_vk197w95j9alkwt8l4g7xkccknhn4pqwx65c5saxnn5ej3cpmps72msgpw69d","previous_block":"9e3f5bfc9f0be44cf6e14db9ed5f1efb6b637baff0ea1740bb6711786c724915","next_block":null,"confirmations":0}}',
+    signatureHeader:
+      't=1650013856,v42=f4c3bb2a8b0c8e21fa7d5fdada2ee87c9c6f6b0b159cc22e483146917e195c3e',
+    secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+    timestampToleranceSeconds: undefined,
+    mockCurrentTimestamp: 1650013856 + 1,
+    result: SignatureVerificationError,
   },
   {
     description: 'valid timestamp (+580s)',
@@ -77,7 +88,7 @@ export const verifyWebhookSignatureFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 610,
-    result: false,
+    result: SignatureVerificationError,
   },
   {
     description: 'valid timestamp (+610s), custom tolerance',
@@ -99,7 +110,7 @@ export const verifyWebhookSignatureFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 1,
-    result: false,
+    result: SignatureVerificationError,
   },
   {
     description: '2 signatures: one valid, one invalid',
@@ -121,7 +132,7 @@ export const verifyWebhookSignatureFixtures = [
     secret: '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
     timestampToleranceSeconds: undefined,
     mockCurrentTimestamp: 1650013856 + 1,
-    result: false,
+    result: SignatureVerificationError,
   },
   {
     description: 'invalid secret',

--- a/test/tests/utils/helpers.ts
+++ b/test/tests/utils/helpers.ts
@@ -1,7 +1,6 @@
 import {
   deriveAddressFixtures,
   verifyWebhookSignatureFixtures,
-  verifyWebhookSignatureErrorFixtures,
 } from '../../fixtures/utils/helpers';
 import {
   deriveAddress,
@@ -33,32 +32,21 @@ describe('helpers', () => {
           .useFakeTimers()
           .setSystemTime(new Date(fixture.mockCurrentTimestamp * 1000));
       }
-      const response = verifyWebhookSignature(
-        fixture.webhookPayload,
-        fixture.signatureHeader,
-        fixture.secret,
-        fixture.timestampToleranceSeconds,
-      );
-      expect(response).toStrictEqual(fixture.result);
-    });
-  });
-
-  verifyWebhookSignatureErrorFixtures.forEach(fixture => {
-    test(`verifyWebhookSignatureErrorFixtures: ${fixture.description}`, () => {
-      if (fixture.mockCurrentTimestamp) {
-        jest
-          .useFakeTimers()
-          .setSystemTime(new Date(fixture.mockCurrentTimestamp * 1000));
-      }
       const response = () =>
         verifyWebhookSignature(
           fixture.webhookPayload,
-          // @ts-expect-error for test and profit
           fixture.signatureHeader,
           fixture.secret,
           fixture.timestampToleranceSeconds,
         );
-      expect(response).toThrowError(SignatureVerificationError);
+
+      if (fixture.result === true) {
+        expect(response()).toStrictEqual(fixture.result);
+      } else {
+        expect(response).toThrowError(SignatureVerificationError);
+      }
+
+      jest.useRealTimers();
     });
   });
 


### PR DESCRIPTION
it was too messy to actually use the verifyWebhookSignature func. Before it could return 3 kind of values: `true`, `false`, or `SignatureVerificationError` and handling all that was cumbersome. Now it either returns true or throws the error and as a bonus we can return additional info explaining why an error was thrown.