### PR TITLE
feat: support for preview and preprod

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const API = new Blockfrost.BlockFrostAPI({
 ### Options
 
 - `projectId` - `string`, Blockfrost project ID (required)
-- `isTestnet` - `boolean`, whether the projectId is intended for testnet network (optional, default value is derived from the `projectId` itself if possible)
+- `network` - `string`, Cardano network for given project ID. (optional, default value is derived from the `projectId` itself if possible). Possible values: `mainnet`, `testnet`, `preview`, `preprod`.
 - `rateLimiter` - `boolean` or [`RateLimiterConfig`](https://github.com/blockfrost/blockfrost-js/blob/master/src/utils/limiter.ts#L18=), whether to enable rate limiter that matches [Blockfrost API limits](https://docs.blockfrost.io/#section/Limits) (optional, default `true`). If you have your IP addresses white-listed you may want to disable it. You may also customize rate limiter by passing your own [config object](ttps://github.com/blockfrost/blockfrost-js/blob/master/src/utils/limiter.ts#11).
 - `requestTimeout` - `number`, How long to wait for a request to complete, in milliseconds (optional, default `20000`)
 - `retrySettings` - `RequiredRetryOptions`, customizations for retrying failed request (optional, [for defaults click here](https://github.com/blockfrost/blockfrost-js/blob/master/src/utils/index.ts#L58))

--- a/examples/simple-transaction/src/index.ts
+++ b/examples/simple-transaction/src/index.ts
@@ -11,8 +11,6 @@ import { signTransaction } from './helpers/signTransaction';
 import { deriveAddressPrvKey, mnemonicToPrivateKey } from './helpers/key';
 import { UTXO } from './types';
 
-const TESTNET = true;
-
 // BIP39 mnemonic (seed) from which we will generate address to retrieve utxo from and private key used for signing the transaction
 const MNEMONIC =
   'maze riot drift silver field sadness shrimp affair whip embody odor damp';
@@ -30,13 +28,14 @@ if (!process.env.BLOCKFROST_PROJECT_ID) {
 
 const client = new BlockFrostAPI({
   projectId: process.env.BLOCKFROST_PROJECT_ID,
-  isTestnet: TESTNET,
+  network: 'testnet',
 });
 
 const run = async () => {
   // Derive an address (this is the address where you need to send ADA in order to have UTXO to actually make the transaction)
   const bip32PrvKey = mnemonicToPrivateKey(MNEMONIC);
-  const { signKey, address } = deriveAddressPrvKey(bip32PrvKey, TESTNET);
+  const testnet = true;
+  const { signKey, address } = deriveAddressPrvKey(bip32PrvKey, testnet);
   console.log(`Using address ${address}`);
 
   // Retrieve utxo for the address

--- a/packages/blockfrost-js/CHANGELOG.MD
+++ b/packages/blockfrost-js/CHANGELOG.MD
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for preview and preprod networks
 - `parseAsset` now also returns `assetNameHex`
+
+### Removed
+
+- BREAKING CHANGE: Removed `isTestnet` option. Network is automatically selected based on the project ID. In case of using legacy Project ID you can manually set `network` option.
 
 ## [4.2.1]
 

--- a/packages/blockfrost-js/src/BlockFrostAPI.ts
+++ b/packages/blockfrost-js/src/BlockFrostAPI.ts
@@ -156,8 +156,14 @@ class BlockFrostAPI {
 
     let apiBase = API_URLS.mainnet;
 
-    if (this.options.isTestnet) {
-      apiBase = API_URLS.testnet;
+    if (this.options.network) {
+      if (this.options.network in API_URLS) {
+        apiBase = API_URLS[this.options.network];
+      } else {
+        throw Error(
+          'Invalid network option. Valid options: mainnet, testnet, preview, preprod.',
+        );
+      }
     }
 
     this.apiUrl =

--- a/packages/blockfrost-js/src/config/index.ts
+++ b/packages/blockfrost-js/src/config/index.ts
@@ -1,6 +1,8 @@
 export const API_URLS = {
   mainnet: 'https://cardano-mainnet.blockfrost.io/api',
   testnet: 'https://cardano-testnet.blockfrost.io/api',
+  preview: 'https://cardano-preview.blockfrost.io/api',
+  preprod: 'https://cardano-preprod.blockfrost.io/api',
   ipfs: 'https://ipfs.blockfrost.io/api',
 };
 

--- a/packages/blockfrost-js/src/types/index.ts
+++ b/packages/blockfrost-js/src/types/index.ts
@@ -36,7 +36,7 @@ type OptionCombination2 = {
 };
 
 type AdditionalOptions = {
-  isTestnet?: boolean;
+  network?: CardanoNetwork;
   version?: number;
   rateLimiter?: boolean | RateLimiterConfig;
   http2?: boolean;
@@ -49,6 +49,8 @@ type AdditionalOptions = {
 export type Options = (OptionCombination1 | OptionCombination2) &
   AdditionalOptions;
 
+export type CardanoNetwork = 'mainnet' | 'testnet' | 'preview' | 'preprod';
+export type BlockfrostNetwork = CardanoNetwork | 'ipfs';
 export interface ValidatedOptions {
   customBackend?: string;
   version: number;
@@ -57,7 +59,7 @@ export interface ValidatedOptions {
   http2?: boolean;
   debug: boolean;
   projectId?: string;
-  isTestnet?: boolean;
+  network?: BlockfrostNetwork;
   retrySettings?: RequiredRetryOptions;
 }
 

--- a/packages/blockfrost-js/src/utils/index.ts
+++ b/packages/blockfrost-js/src/utils/index.ts
@@ -12,6 +12,7 @@ import {
   PaginationOptions,
   AdditionalEndpointOptions,
   AllMethodOptions,
+  BlockfrostNetwork,
 } from '../types';
 import { RetryObject } from 'got';
 import { RATE_LIMITER_DEFAULT_CONFIG } from './limiter';
@@ -64,9 +65,7 @@ export const validateOptions = (options?: Options): ValidatedOptions => {
   return {
     customBackend: options.customBackend,
     projectId: options.projectId,
-    isTestnet:
-      options.isTestnet ??
-      deriveTestnetOption(options.projectId, options.isTestnet),
+    network: options.network ?? deriveNetworkOption(options.projectId),
     rateLimiter,
     version: options.version || DEFAULT_API_VERSION,
     debug,
@@ -104,32 +103,27 @@ export const validateOptions = (options?: Options): ValidatedOptions => {
   };
 };
 
-const deriveTestnetOption = (
+const deriveNetworkOption = (
   projectId: string | undefined,
-  isTestnet: boolean | undefined,
-) => {
+): BlockfrostNetwork | undefined => {
   if (!projectId) return undefined;
 
-  if (projectId.includes('mainnet')) {
-    return false;
-  }
-
-  if (projectId.includes('testnet')) {
-    return true;
-  }
-
-  if (projectId.includes('ipfs')) {
-    return false;
-  }
-
-  if (!isTestnet) {
-    console.log(
-      'WARNING: Old token was used without isTestnet parameter switching to mainnet network',
+  if (projectId.startsWith('mainnet')) {
+    return 'mainnet';
+  } else if (projectId.startsWith('testnet')) {
+    return 'testnet';
+  } else if (projectId.startsWith('preview')) {
+    return 'preview';
+  } else if (projectId.startsWith('preprod')) {
+    return 'preprod';
+  } else if (projectId.startsWith('ipfs')) {
+    return 'ipfs';
+  } else {
+    console.warn(
+      'WARNING: Old token was used without network parameter. Switching to mainnet network',
     );
-    return false;
+    return 'mainnet';
   }
-
-  return undefined;
 };
 
 export const getAdditionalParams = (

--- a/packages/blockfrost-js/test/setup.ts
+++ b/packages/blockfrost-js/test/setup.ts
@@ -1,7 +1,7 @@
 // import { TextDecoder } from 'text-encoding';
 import { expect, jest } from '@jest/globals';
 
-jest.setTimeout(60000);
+jest.setTimeout(80000);
 
 expect.extend({
   toBeTypeOrNull(received, classTypeOrNull) {

--- a/packages/blockfrost-js/test/tests/utils/utils.ts
+++ b/packages/blockfrost-js/test/tests/utils/utils.ts
@@ -18,20 +18,33 @@ describe('utils', () => {
     expect(api.projectId).toBe('xxx');
   });
 
-  test('isTestnet', () => {
+  test('init BlockFrostAPI with different networks', () => {
     const api = new BlockFrostAPI({
       projectId: 'xxx',
-      isTestnet: true,
+      network: 'testnet',
     });
 
     expect(api.apiUrl).toBe('https://cardano-testnet.blockfrost.io/api/v0');
 
     const api2 = new BlockFrostAPI({
       projectId: 'xxx',
-      isTestnet: false,
+      network: 'mainnet',
     });
 
     expect(api2.apiUrl).toBe('https://cardano-mainnet.blockfrost.io/api/v0');
+
+    const api3 = new BlockFrostAPI({
+      projectId: 'xxx',
+      network: 'preprod',
+    });
+
+    expect(api3.apiUrl).toBe('https://cardano-preprod.blockfrost.io/api/v0');
+    const api4 = new BlockFrostAPI({
+      projectId: 'xxx',
+      network: 'preview',
+    });
+
+    expect(api4.apiUrl).toBe('https://cardano-preview.blockfrost.io/api/v0');
   });
 
   test('version', () => {
@@ -72,7 +85,7 @@ describe('utils', () => {
   test('customBackend', () => {
     const api = new BlockFrostAPI({
       customBackend: 'http://customBackend.com',
-      isTestnet: false,
+      network: 'mainnet',
     });
 
     expect(api.apiUrl).toBe('http://customBackend.com');
@@ -102,7 +115,7 @@ describe('utils', () => {
 
     expect(api.options).toMatchObject({
       customBackend: undefined,
-      isTestnet: false,
+      network: 'mainnet',
       projectId: 'xxx',
       requestTimeout: 20000,
       rateLimiter: RATE_LIMITER_DEFAULT_CONFIG,
@@ -134,7 +147,7 @@ describe('utils', () => {
 
     expect(api.options).toMatchObject({
       customBackend: undefined,
-      isTestnet: false,
+      network: 'mainnet',
       projectId: 'xxx',
       http2: false,
       requestTimeout: 20000,
@@ -209,7 +222,7 @@ describe('utils', () => {
 
     expect(api.options).toMatchObject({
       customBackend: undefined,
-      isTestnet: false,
+      network: 'mainnet',
       http2: false,
       projectId: 'mainnetxxx',
       requestTimeout: 1,


### PR DESCRIPTION
done as breaking change due to removing `isTestnet`, alternatively in addition to new option `network` we could also keep `isTestnet` (probably mark it as deprecated) and map it to either `mainnet` or `testnet`. I assume 99% are using project ids with a prefix so they don't need to set isTestnet anyway and this could be nice way to force them to stop manually specifying network.

testing needed

resolves https://github.com/blockfrost/blockfrost-js/issues/232