### PR TITLE
chore: remove unnecessary promise wrap

### DIFF
--- a/src/endpoints/api/accounts/index.ts
+++ b/src/endpoints/api/accounts/index.ts
@@ -16,15 +16,14 @@ export async function accounts(
   this: BlockFrostAPI,
   stakeAddress: string,
 ): Promise<components['schemas']['account_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_content']>(
+  try {
+    const res = await this.instance<components['schemas']['account_content']>(
       `accounts/${stakeAddress}`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -43,22 +42,20 @@ export async function accountsRewards(
 ): Promise<components['schemas']['account_reward_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_reward_content']>(
-      `accounts/${stakeAddress}/rewards`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_reward_content']
+    >(`accounts/${stakeAddress}/rewards`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -99,22 +96,20 @@ export async function accountsHistory(
 ): Promise<components['schemas']['account_history_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_history_content']>(
-      `accounts/${stakeAddress}/history`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_history_content']
+    >(`accounts/${stakeAddress}/history`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -155,22 +150,20 @@ export async function accountsWithdrawals(
 ): Promise<components['schemas']['account_withdrawal_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_withdrawal_content']>(
-      `accounts/${stakeAddress}/withdrawals`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_withdrawal_content']
+    >(`accounts/${stakeAddress}/withdrawals`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -211,22 +204,20 @@ export async function accountsMirs(
 ): Promise<components['schemas']['account_mir_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_mir_content']>(
-      `accounts/${stakeAddress}/mirs`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_mir_content']
+    >(`accounts/${stakeAddress}/mirs`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -267,22 +258,20 @@ export async function accountsDelegations(
 ): Promise<components['schemas']['account_delegation_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_delegation_content']>(
-      `accounts/${stakeAddress}/delegations`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_delegation_content']
+    >(`accounts/${stakeAddress}/delegations`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -323,22 +312,20 @@ export async function accountsRegistrations(
 ): Promise<components['schemas']['account_registration_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_registration_content']>(
-      `accounts/${stakeAddress}/registrations`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_registration_content']
+    >(`accounts/${stakeAddress}/registrations`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -382,22 +369,20 @@ export async function accountsAddresses(
 ): Promise<components['schemas']['account_addresses_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_addresses_content']>(
-      `accounts/${stakeAddress}/addresses`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_addresses_content']
+    >(`accounts/${stakeAddress}/addresses`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -441,22 +426,20 @@ export async function accountsAddressesAssets(
 ): Promise<components['schemas']['account_addresses_assets']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_addresses_assets']>(
-      `accounts/${stakeAddress}/addresses/assets`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['account_addresses_assets']
+    >(`accounts/${stakeAddress}/addresses/assets`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -493,13 +476,12 @@ export async function accountsAddressesTotal(
   this: BlockFrostAPI,
   stakeAddress: string,
 ): Promise<components['schemas']['account_addresses_total']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['account_addresses_total']>(
-      `accounts/${stakeAddress}/addresses/total`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['account_addresses_total']
+    >(`accounts/${stakeAddress}/addresses/total`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/addresses/index.ts
+++ b/src/endpoints/api/addresses/index.ts
@@ -11,6 +11,7 @@ import {
   AdditionalEndpointOptions,
   AllMethodOptions,
 } from '../../../types';
+import { HTTPError } from 'got';
 
 /**
  * Obtains information about a specific address.
@@ -24,15 +25,14 @@ export async function addresses(
   this: BlockFrostAPI,
   address: string,
 ): Promise<components['schemas']['address_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['address_content']>(
+  try {
+    const res = await this.instance<components['schemas']['address_content']>(
       `addresses/${address}`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -48,15 +48,14 @@ export async function addressesTotal(
   this: BlockFrostAPI,
   address: string,
 ): Promise<components['schemas']['address_content_total']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['address_content_total']>(
-      `addresses/${address}/total`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['address_content_total']
+    >(`addresses/${address}/total`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -72,15 +71,14 @@ export async function addressesExtended(
   this: BlockFrostAPI,
   address: string,
 ): Promise<components['schemas']['address_content_extended']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['address_content_extended']>(
-      `addresses/${address}/extended`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['address_content_extended']
+    >(`addresses/${address}/extended`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -102,30 +100,25 @@ export async function addressesTransactions(
   const additionalParams = getAdditionalParams(additionalOptions);
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['address_transactions_content']>(
-      `addresses/${address}/transactions`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-          from: additionalParams.from,
-          to: additionalParams.to,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['address_transactions_content']
+    >(`addresses/${address}/transactions`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
+        from: additionalParams.from,
+        to: additionalParams.to,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        if (err && err.response && err.response.statusCode === 404) {
-          resolve([]);
-        }
-
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.statusCode === 404) {
+      return [];
+    }
+    throw handleError(error);
+  }
 }
 
 /**
@@ -170,22 +163,20 @@ export async function addressesUtxos(
 ): Promise<components['schemas']['address_utxo_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['address_utxo_content']>(
-      `addresses/${address}/utxos`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['address_utxo_content']
+    >(`addresses/${address}/utxos`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -229,22 +220,20 @@ export async function addressesUtxosAsset(
   // TODO: test is missing since we can't guarantee that list of address's utxos won't change in the future
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['address_utxo_content']>(
-      `addresses/${address}/utxos/${asset}`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['address_utxo_content']
+    >(`addresses/${address}/utxos/${asset}`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**

--- a/src/endpoints/api/assets/index.ts
+++ b/src/endpoints/api/assets/index.ts
@@ -21,19 +21,18 @@ export async function assets(
 ): Promise<components['schemas']['assets']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['assets']>(`assets`, {
+  try {
+    const res = await this.instance<components['schemas']['assets']>(`assets`, {
       searchParams: {
         page: paginationOptions.page,
         count: paginationOptions.count,
         order: paginationOptions.order,
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -48,13 +47,14 @@ export async function assetsById(
   this: BlockFrostAPI,
   asset: string,
 ): Promise<components['schemas']['asset']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['asset']>(`assets/${asset}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+  try {
+    const res = await this.instance<components['schemas']['asset']>(
+      `assets/${asset}`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -73,8 +73,8 @@ export async function assetsHistory(
 ): Promise<components['schemas']['asset_history']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['asset_history']>(
+  try {
+    const res = await this.instance<components['schemas']['asset_history']>(
       `assets/${asset}/history`,
       {
         searchParams: {
@@ -83,12 +83,11 @@ export async function assetsHistory(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -129,22 +128,20 @@ export async function assetsTransactions(
 ): Promise<components['schemas']['asset_transactions']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['asset_transactions']>(
-      `assets/${asset}/transactions`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['asset_transactions']
+    >(`assets/${asset}/transactions`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -163,8 +160,8 @@ export async function assetsAddresses(
 ): Promise<components['schemas']['asset_addresses']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['asset_addresses']>(
+  try {
+    const res = await this.instance<components['schemas']['asset_addresses']>(
       `assets/${asset}/addresses`,
       {
         searchParams: {
@@ -173,12 +170,11 @@ export async function assetsAddresses(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -197,8 +193,8 @@ export async function assetsPolicyById(
 ): Promise<components['schemas']['asset_policy']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['asset_policy']>(
+  try {
+    const res = await this.instance<components['schemas']['asset_policy']>(
       `assets/policy/${policyId}`,
       {
         searchParams: {
@@ -207,12 +203,11 @@ export async function assetsPolicyById(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**

--- a/src/endpoints/api/blocks/index.ts
+++ b/src/endpoints/api/blocks/index.ts
@@ -20,17 +20,14 @@ export async function blocks(
   this: BlockFrostAPI,
   hashOrNumber: HashOrNumber,
 ): Promise<components['schemas']['block_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content']>(
+  try {
+    const res = await this.instance<components['schemas']['block_content']>(
       `blocks/${hashOrNumber}`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -43,15 +40,15 @@ export async function blocks(
 export async function blocksLatest(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['block_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content']>(`blocks/latest`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res =
+      await this.instance<components['schemas']['block_content']>(
+        `blocks/latest`,
+      );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -68,8 +65,8 @@ export async function blocksLatestTxs(
 ): Promise<components['schemas']['block_content_txs']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content_txs']>(
+  try {
+    const res = await this.instance<components['schemas']['block_content_txs']>(
       `blocks/latest/txs`,
       {
         searchParams: {
@@ -78,14 +75,11 @@ export async function blocksLatestTxs(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        return reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -124,23 +118,20 @@ export async function blocksNext(
 ): Promise<components['schemas']['block_content_array']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content_array']>(
-      `blocks/${hashOrNumber}/next`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['block_content_array']
+    >(`blocks/${hashOrNumber}/next`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -159,23 +150,19 @@ export async function blocksPrevious(
 ): Promise<components['schemas']['block_content_array']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content_array']>(
-      `blocks/${hashOrNumber}/previous`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['block_content_array']
+    >(`blocks/${hashOrNumber}/previous`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -194,8 +181,8 @@ export async function blocksTxs(
 ): Promise<components['schemas']['block_content_txs']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content_txs']>(
+  try {
+    const res = await this.instance<components['schemas']['block_content_txs']>(
       `blocks/${hashOrNumber}/txs`,
       {
         searchParams: {
@@ -204,14 +191,11 @@ export async function blocksTxs(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -254,24 +238,20 @@ export async function blocksAddresses(
 ): Promise<components['schemas']['block_content_addresses']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['block_content_addresses']>(
-      `blocks/${hashOrNumber}/addresses`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          // order: paginationOptions.order, // no ordering on /blocks/{hash}/addresses
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['block_content_addresses']
+    >(`blocks/${hashOrNumber}/addresses`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        // order: paginationOptions.order, // no ordering on /blocks/{hash}/addresses
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**

--- a/src/endpoints/api/epochs/index.ts
+++ b/src/endpoints/api/epochs/index.ts
@@ -16,15 +16,14 @@ export async function epochs(
   this: BlockFrostAPI,
   number: number,
 ): Promise<components['schemas']['epoch_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_content']>(`epochs/${number}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<components['schemas']['epoch_content']>(
+      `epochs/${number}`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -37,15 +36,15 @@ export async function epochs(
 export async function epochsLatest(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['epoch_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_content']>(`epochs/latest`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res =
+      await this.instance<components['schemas']['epoch_content']>(
+        `epochs/latest`,
+      );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -64,23 +63,19 @@ export async function epochsNext(
 ): Promise<components['schemas']['epoch_content_array']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_content_array']>(
-      `epochs/${number}/next`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_content_array']
+    >(`epochs/${number}/next`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -99,23 +94,19 @@ export async function epochsPrevious(
 ): Promise<components['schemas']['epoch_content_array']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_content_array']>(
-      `epochs/${number}/previous`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_content_array']
+    >(`epochs/${number}/previous`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -134,24 +125,20 @@ export async function epochsStakes(
 ): Promise<components['schemas']['epoch_stake_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_stake_content']>(
-      `epochs/${number}/stakes`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_stake_content']
+    >(`epochs/${number}/stakes`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -194,24 +181,20 @@ export async function epochsStakesByPoolId(
 ): Promise<components['schemas']['epoch_stake_pool_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_stake_pool_content']>(
-      `epochs/${number}/stakes/${poolId}`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_stake_pool_content']
+    >(`epochs/${number}/stakes/${poolId}`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -254,24 +237,20 @@ export async function epochsBlocks(
 ): Promise<components['schemas']['epoch_block_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_block_content']>(
-      `epochs/${number}/blocks`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_block_content']
+    >(`epochs/${number}/blocks`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -314,24 +293,20 @@ export async function epochsBlocksByPoolId(
 ): Promise<components['schemas']['epoch_block_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_block_content']>(
-      `epochs/${number}/blocks/${poolId}`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_block_content']
+    >(`epochs/${number}/blocks/${poolId}`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -370,17 +345,14 @@ export async function epochsParameters(
   this: BlockFrostAPI,
   number: number,
 ): Promise<components['schemas']['epoch_param_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_param_content']>(
-      `epochs/${number}/parameters`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_param_content']
+    >(`epochs/${number}/parameters`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -393,15 +365,12 @@ export async function epochsParameters(
 export async function epochsLatestParameters(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['epoch_param_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['epoch_param_content']>(
-      `epochs/latest/parameters`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['epoch_param_content']
+    >(`epochs/latest/parameters`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/health/index.ts
+++ b/src/endpoints/api/health/index.ts
@@ -10,16 +10,15 @@ import { BlockFrostAPI } from '../../../index';
  * @returns Backend status in the format `{is_healthy: boolean}`
  *
  */
-export function health(this: BlockFrostAPI): Promise<{ is_healthy: boolean }> {
-  return new Promise((resolve, reject) => {
-    this.instance<{ is_healthy: boolean }>(`health`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+export async function health(
+  this: BlockFrostAPI,
+): Promise<{ is_healthy: boolean }> {
+  try {
+    const res = await this.instance<{ is_healthy: boolean }>(`health`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -29,16 +28,13 @@ export function health(this: BlockFrostAPI): Promise<{ is_healthy: boolean }> {
  * @returns Unix time in the format `{server_time: number}`
  *
  */
-export function healthClock(
+export async function healthClock(
   this: BlockFrostAPI,
 ): Promise<{ server_time: number }> {
-  return new Promise((resolve, reject) => {
-    this.instance<{ server_time: number }>(`health/clock`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<{ server_time: number }>(`health/clock`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/ledger/index.ts
+++ b/src/endpoints/api/ledger/index.ts
@@ -9,16 +9,14 @@ import { BlockFrostAPI } from '../../../index';
  * @returns Genesis parameters
  *
  */
-export function genesis(
+export async function genesis(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['genesis_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['genesis_content']>(`genesis`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res =
+      await this.instance<components['schemas']['genesis_content']>(`genesis`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/mempool/index.ts
+++ b/src/endpoints/api/mempool/index.ts
@@ -20,21 +20,21 @@ export async function mempool(
 ): Promise<components['schemas']['mempool_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['mempool_content']>(`mempool`, {
-      searchParams: {
-        page: paginationOptions.page,
-        count: paginationOptions.count,
-        order: paginationOptions.order,
+  try {
+    const res = await this.instance<components['schemas']['mempool_content']>(
+      `mempool`,
+      {
+        searchParams: {
+          page: paginationOptions.page,
+          count: paginationOptions.count,
+          order: paginationOptions.order,
+        },
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -71,17 +71,14 @@ export async function mempoolTx(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['mempool_tx_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['mempool_tx_content']>(
-      `mempool/${hash}`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['mempool_tx_content']
+    >(`mempool/${hash}`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -101,8 +98,8 @@ export async function mempoolByAddress(
 ): Promise<components['schemas']['mempool_addresses_content']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['mempool_content']>(
+  try {
+    const res = await this.instance<components['schemas']['mempool_content']>(
       `mempool/addresses/${address}`,
       {
         searchParams: {
@@ -111,14 +108,11 @@ export async function mempoolByAddress(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**

--- a/src/endpoints/api/metadata/index.ts
+++ b/src/endpoints/api/metadata/index.ts
@@ -18,24 +18,20 @@ export async function metadataTxsLabels(
 ): Promise<components['schemas']['tx_metadata_labels']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_metadata_labels']>(
-      `metadata/txs/labels`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_metadata_labels']
+    >(`metadata/txs/labels`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -54,24 +50,20 @@ export async function metadataTxsLabel(
 ): Promise<components['schemas']['tx_metadata_label_json']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_metadata_label_json']>(
-      `metadata/txs/labels/${label}`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_metadata_label_json']
+    >(`metadata/txs/labels/${label}`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -90,22 +82,18 @@ export async function metadataTxsLabelCbor(
 ): Promise<components['schemas']['tx_metadata_label_cbor']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_metadata_label_cbor']>(
-      `metadata/txs/labels/${label}/cbor`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_metadata_label_cbor']
+    >(`metadata/txs/labels/${label}/cbor`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/metrics/index.ts
+++ b/src/endpoints/api/metrics/index.ts
@@ -12,15 +12,13 @@ import { BlockFrostAPI } from '../../../index';
 export async function metrics(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['metrics']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['metrics']>(`metrics`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res =
+      await this.instance<components['schemas']['metrics']>(`metrics`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -33,13 +31,13 @@ export async function metrics(
 export async function metricsEndpoints(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['metrics']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['metrics']>(`metrics/endpoints`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res =
+      await this.instance<components['schemas']['metrics']>(
+        `metrics/endpoints`,
+      );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/network/index.ts
+++ b/src/endpoints/api/network/index.ts
@@ -12,13 +12,11 @@ import { components } from '@blockfrost/openapi';
 export async function network(
   this: BlockFrostAPI,
 ): Promise<components['schemas']['network']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['network']>(`network`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res =
+      await this.instance<components['schemas']['network']>(`network`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/nutlink/index.ts
+++ b/src/endpoints/api/nutlink/index.ts
@@ -8,15 +8,14 @@ export async function nutlinkAddress(
   this: BlockFrostAPI,
   address: string,
 ): Promise<components['schemas']['nutlink_address']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['nutlink_address']>(
+  try {
+    const res = await this.instance<components['schemas']['nutlink_address']>(
       `nutlink/${address}`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 export async function nutlinkAddressTickers(
@@ -26,22 +25,20 @@ export async function nutlinkAddressTickers(
 ): Promise<components['schemas']['nutlink_address_tickers']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['nutlink_address_tickers']>(
-      `nutlink/${address}/tickers`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['nutlink_address_tickers']
+    >(`nutlink/${address}/tickers`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 export async function nutlinkAddressTickersAll(
@@ -63,22 +60,20 @@ export async function nutlinkAddressTicker(
 ): Promise<components['schemas']['nutlink_address_ticker']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['nutlink_address_ticker']>(
-      `nutlink/${address}/tickers/${ticker}`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['nutlink_address_ticker']
+    >(`nutlink/${address}/tickers/${ticker}`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 export async function nutlinkAddressTickerAll(
@@ -100,22 +95,20 @@ export async function nutlinkTickers(
 ): Promise<components['schemas']['nutlink_tickers_ticker']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['nutlink_tickers_ticker']>(
-      `nutlink/tickers/${ticker}`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['nutlink_tickers_ticker']
+    >(`nutlink/tickers/${ticker}`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => reject(handleError(err)));
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 export async function nutlinkTickersAll(

--- a/src/endpoints/api/pools/index.ts
+++ b/src/endpoints/api/pools/index.ts
@@ -18,21 +18,21 @@ export async function pools(
 ): Promise<components['schemas']['pool_list']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_list']>(`pools`, {
-      searchParams: {
-        page: paginationOptions.page,
-        count: paginationOptions.count,
-        order: paginationOptions.order,
+  try {
+    const res = await this.instance<components['schemas']['pool_list']>(
+      `pools`,
+      {
+        searchParams: {
+          page: paginationOptions.page,
+          count: paginationOptions.count,
+          order: paginationOptions.order,
+        },
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -58,21 +58,21 @@ export async function poolsRetired(
 ): Promise<components['schemas']['pool_list_retire']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_list_retire']>(`pools/retired`, {
-      searchParams: {
-        page: paginationOptions.page,
-        count: paginationOptions.count,
-        order: paginationOptions.order,
+  try {
+    const res = await this.instance<components['schemas']['pool_list_retire']>(
+      `pools/retired`,
+      {
+        searchParams: {
+          page: paginationOptions.page,
+          count: paginationOptions.count,
+          order: paginationOptions.order,
+        },
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -89,21 +89,21 @@ export async function poolsRetiring(
 ): Promise<components['schemas']['pool_list_retire']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_list_retire']>(`pools/retiring`, {
-      searchParams: {
-        page: paginationOptions.page,
-        count: paginationOptions.count,
-        order: paginationOptions.order,
+  try {
+    const res = await this.instance<components['schemas']['pool_list_retire']>(
+      `pools/retiring`,
+      {
+        searchParams: {
+          page: paginationOptions.page,
+          count: paginationOptions.count,
+          order: paginationOptions.order,
+        },
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -118,15 +118,14 @@ export async function poolsById(
   this: BlockFrostAPI,
   poolId: string,
 ): Promise<components['schemas']['pool']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool']>(`pools/${poolId}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<components['schemas']['pool']>(
+      `pools/${poolId}`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -145,8 +144,8 @@ export async function poolsByIdHistory(
 ): Promise<components['schemas']['pool_history']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_history']>(
+  try {
+    const res = await this.instance<components['schemas']['pool_history']>(
       `pools/${poolId}/history`,
       {
         searchParams: {
@@ -155,14 +154,11 @@ export async function poolsByIdHistory(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -177,17 +173,14 @@ export async function poolMetadata(
   this: BlockFrostAPI,
   poolId: string,
 ): Promise<components['schemas']['pool_metadata']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_metadata']>(
+  try {
+    const res = await this.instance<components['schemas']['pool_metadata']>(
       `pools/${poolId}/metadata`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -202,17 +195,14 @@ export async function poolsByIdRelays(
   this: BlockFrostAPI,
   poolId: string,
 ): Promise<components['schemas']['pool_relays']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_relays']>(
+  try {
+    const res = await this.instance<components['schemas']['pool_relays']>(
       `pools/${poolId}/relays`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -230,8 +220,8 @@ export async function poolsByIdDelegators(
 ): Promise<components['schemas']['pool_delegators']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_delegators']>(
+  try {
+    const res = await this.instance<components['schemas']['pool_delegators']>(
       `pools/${poolId}/delegators`,
       {
         searchParams: {
@@ -240,14 +230,11 @@ export async function poolsByIdDelegators(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -266,8 +253,8 @@ export async function poolsByIdBlocks(
 ): Promise<components['schemas']['pool_blocks']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_blocks']>(
+  try {
+    const res = await this.instance<components['schemas']['pool_blocks']>(
       `pools/${poolId}/blocks`,
       {
         searchParams: {
@@ -276,14 +263,11 @@ export async function poolsByIdBlocks(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -302,8 +286,8 @@ export async function poolsByIdUpdates(
 ): Promise<components['schemas']['pool_updates']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_updates']>(
+  try {
+    const res = await this.instance<components['schemas']['pool_updates']>(
       `pools/${poolId}/updates`,
       {
         searchParams: {
@@ -312,14 +296,11 @@ export async function poolsByIdUpdates(
           order: paginationOptions.order,
         },
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -335,24 +316,20 @@ export async function poolsExtended(
 ): Promise<components['schemas']['pool_list_extended']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['pool_list_extended']>(
-      `pools/extended`,
-      {
-        searchParams: {
-          page: paginationOptions.page,
-          count: paginationOptions.count,
-          order: paginationOptions.order,
-        },
+  try {
+    const res = await this.instance<
+      components['schemas']['pool_list_extended']
+    >(`pools/extended`, {
+      searchParams: {
+        page: paginationOptions.page,
+        count: paginationOptions.count,
+        order: paginationOptions.order,
       },
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**

--- a/src/endpoints/api/root/index.ts
+++ b/src/endpoints/api/root/index.ts
@@ -10,13 +10,10 @@ import { BlockFrostAPI } from '../../../index';
 export async function root(
   this: BlockFrostAPI,
 ): Promise<{ url: string; version: string }> {
-  return new Promise((resolve, reject) => {
-    this.instance<{ url: string; version: string }>(``)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<{ url: string; version: string }>(``);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/scripts/index.ts
+++ b/src/endpoints/api/scripts/index.ts
@@ -16,15 +16,14 @@ export async function scriptsByHash(
   this: BlockFrostAPI,
   scriptHash: string,
 ): Promise<components['schemas']['script']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['script']>(`scripts/${scriptHash}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<components['schemas']['script']>(
+      `scripts/${scriptHash}`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -41,21 +40,21 @@ export async function scripts(
 ): Promise<components['schemas']['scripts']> {
   const paginationOptions = getPaginationOptions(pagination);
 
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['scripts']>(`scripts`, {
-      searchParams: {
-        page: paginationOptions.page,
-        count: paginationOptions.count,
-        order: paginationOptions.order,
+  try {
+    const res = await this.instance<components['schemas']['scripts']>(
+      `scripts`,
+      {
+        searchParams: {
+          page: paginationOptions.page,
+          count: paginationOptions.count,
+          order: paginationOptions.order,
+        },
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -70,17 +69,14 @@ export async function scriptsJson(
   this: BlockFrostAPI,
   scriptHash: string,
 ): Promise<components['schemas']['script_json']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['script_json']>(
+  try {
+    const res = await this.instance<components['schemas']['script_json']>(
       `scripts/${scriptHash}/json`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -95,17 +91,14 @@ export async function scriptsCbor(
   this: BlockFrostAPI,
   scriptHash: string,
 ): Promise<components['schemas']['script_cbor']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['script_cbor']>(
+  try {
+    const res = await this.instance<components['schemas']['script_cbor']>(
       `scripts/${scriptHash}/cbor`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -120,17 +113,14 @@ export async function scriptsDatum(
   this: BlockFrostAPI,
   datumHash: string,
 ): Promise<components['schemas']['script_datum']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['script_datum']>(
+  try {
+    const res = await this.instance<components['schemas']['script_datum']>(
       `scripts/datum/${datumHash}`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -145,17 +135,14 @@ export async function scriptsDatumCbor(
   this: BlockFrostAPI,
   datumHash: string,
 ): Promise<components['schemas']['script_datum_cbor']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['script_datum_cbor']>(
+  try {
+    const res = await this.instance<components['schemas']['script_datum_cbor']>(
       `scripts/datum/${datumHash}/cbor`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -170,15 +157,12 @@ export async function scriptsRedeemers(
   this: BlockFrostAPI,
   scriptHash: string,
 ): Promise<components['schemas']['script_redeemers']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['script_redeemers']>(
+  try {
+    const res = await this.instance<components['schemas']['script_redeemers']>(
       `scripts/${scriptHash}/redeemers`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/txs/index.ts
+++ b/src/endpoints/api/txs/index.ts
@@ -14,15 +14,14 @@ export async function txs(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content']>(`txs/${hash}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<components['schemas']['tx_content']>(
+      `txs/${hash}`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -37,15 +36,14 @@ export async function txsUtxos(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_utxo']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_utxo']>(`txs/${hash}/utxos`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<components['schemas']['tx_content_utxo']>(
+      `txs/${hash}/utxos`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -60,17 +58,14 @@ export async function txsStakes(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_stake_addr']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_stake_addr']>(
-      `txs/${hash}/stakes`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_stake_addr']
+    >(`txs/${hash}/stakes`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -85,17 +80,14 @@ export async function txsDelegations(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_delegations']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_delegations']>(
-      `txs/${hash}/delegations`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_delegations']
+    >(`txs/${hash}/delegations`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -110,17 +102,14 @@ export async function txsWithdrawals(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_withdrawals']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_withdrawals']>(
-      `txs/${hash}/withdrawals`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_withdrawals']
+    >(`txs/${hash}/withdrawals`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -135,15 +124,14 @@ export async function txsMirs(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_mirs']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_mirs']>(`txs/${hash}/mirs`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<components['schemas']['tx_content_mirs']>(
+      `txs/${hash}/mirs`,
+    );
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -158,17 +146,14 @@ export async function txsPoolUpdates(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_pool_certs']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_pool_certs']>(
-      `txs/${hash}/pool_updates`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_pool_certs']
+    >(`txs/${hash}/pool_updates`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -183,17 +168,14 @@ export async function txsPoolRetires(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_pool_retires']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_pool_retires']>(
-      `txs/${hash}/pool_retires`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_pool_retires']
+    >(`txs/${hash}/pool_retires`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -208,17 +190,14 @@ export async function txsMetadata(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_metadata']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_metadata']>(
-      `txs/${hash}/metadata`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_metadata']
+    >(`txs/${hash}/metadata`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -233,17 +212,14 @@ export async function txsMetadataCbor(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_metadata_cbor']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_metadata_cbor']>(
-      `txs/${hash}/metadata/cbor`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_metadata_cbor']
+    >(`txs/${hash}/metadata/cbor`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -258,17 +234,14 @@ export async function txsRedeemers(
   this: BlockFrostAPI,
   hash: string,
 ): Promise<components['schemas']['tx_content_redeemers']> {
-  return new Promise((resolve, reject) => {
-    this.instance<components['schemas']['tx_content_redeemers']>(
-      `txs/${hash}/redeemers`,
-    )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<
+      components['schemas']['tx_content_redeemers']
+    >(`txs/${hash}/redeemers`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -291,17 +264,13 @@ export async function txSubmit(
     tx = Buffer.from(transaction);
   }
 
-  return new Promise((resolve, reject) => {
-    this.instance
-      .post(`tx/submit`, {
-        body: tx,
-        headers: { 'Content-type': 'application/cbor' },
-      })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.post(`tx/submit`, {
+      body: tx,
+      headers: { 'Content-type': 'application/cbor' },
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/api/utils/txs.ts
+++ b/src/endpoints/api/utils/txs.ts
@@ -26,22 +26,17 @@ export async function utilsTxsEvaluate(
     tx = Buffer.from(transaction).toString('hex');
   }
 
-  return new Promise((resolve, reject) => {
-    this.instance
-      .post<paths['/utils/txs/evaluate']['post']['responses']['200']>(
-        `utils/txs/evaluate`,
-        {
-          body: tx,
-          headers: { 'Content-type': 'application/cbor' },
-        },
-      )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.post<
+      paths['/utils/txs/evaluate']['post']['responses']['200']
+    >(`utils/txs/evaluate`, {
+      body: tx,
+      headers: { 'Content-type': 'application/cbor' },
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -60,23 +55,18 @@ export async function utilsTxsEvaluateUtxos(
   // additionalUtxoSet: paths['/utils/txs/evaluate/utxos']['post']['requestBody']['content']['application/json'],
   additionalUtxoSet: [TxIn, TxOut][],
 ): Promise<paths['/utils/txs/evaluate']['post']['responses']['200']> {
-  return new Promise((resolve, reject) => {
-    this.instance
-      .post<paths['/utils/txs/evaluate/utxos']['post']['responses']['200']>(
-        `utils/txs/evaluate/utxos`,
-        {
-          body: betterJSON.stringify({
-            cbor: transaction,
-            additionalUtxoSet,
-          }),
-          headers: { 'Content-type': 'application/json' },
-        },
-      )
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.post<
+      paths['/utils/txs/evaluate/utxos']['post']['responses']['200']
+    >(`utils/txs/evaluate/utxos`, {
+      body: betterJSON.stringify({
+        cbor: transaction,
+        additionalUtxoSet,
+      }),
+      headers: { 'Content-type': 'application/json' },
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/endpoints/ipfs/index.ts
+++ b/src/endpoints/ipfs/index.ts
@@ -24,21 +24,17 @@ export async function add(
 
   data.append('file', stream);
 
-  return new Promise((resolve, reject) => {
-    this.instance
-      .post<AddResponse>(`ipfs/add`, {
-        body: data,
-        headers: {
-          'Content-Type': `multipart/form-data; boundary=${data.getBoundary()}`,
-        },
-      })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.post<AddResponse>(`ipfs/add`, {
+      body: data,
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${data.getBoundary()}`,
+      },
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -55,18 +51,14 @@ export async function gateway(
   this: BlockFrostIPFS,
   path: string,
 ): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    this.instance
-      .get(`ipfs/gateway`, {
-        searchParams: { path },
-      })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.get(`ipfs/gateway`, {
+      searchParams: { path },
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -82,16 +74,12 @@ export async function pin(
   this: BlockFrostIPFS,
   path: string,
 ): Promise<PinResponse> {
-  return new Promise((resolve, reject) => {
-    this.instance
-      .post<PinResponse>(`ipfs/pin/add/${path}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.post<PinResponse>(`ipfs/pin/add/${path}`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -107,21 +95,18 @@ export async function list(
   pagination?: PaginationOptions,
 ): Promise<ListResponse> {
   const paginationOptions = getPaginationOptions(pagination);
-  return new Promise((resolve, reject) => {
-    this.instance<ListResponse>(`ipfs/pin/list`, {
+  try {
+    const res = await this.instance<ListResponse>(`ipfs/pin/list`, {
       searchParams: {
         page: paginationOptions.page,
         count: paginationOptions.count,
         order: paginationOptions.order,
       },
-    })
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+    });
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -136,15 +121,12 @@ export async function listByPath(
   this: BlockFrostIPFS,
   path: string,
 ): Promise<ListResponse> {
-  return new Promise((resolve, reject) => {
-    this.instance<ListResponse>(`ipfs/pin/list/${path}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance<ListResponse>(`ipfs/pin/list/${path}`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }
 
 /**
@@ -159,14 +141,10 @@ export async function pinRemove(
   this: BlockFrostIPFS,
   path: string,
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    this.instance
-      .post<string>(`ipfs/pin/remove/${path}`)
-      .then(resp => {
-        resolve(resp.body);
-      })
-      .catch(err => {
-        reject(handleError(err));
-      });
-  });
+  try {
+    const res = await this.instance.post<string>(`ipfs/pin/remove/${path}`);
+    return res.body;
+  } catch (error) {
+    throw handleError(error);
+  }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -70,7 +70,7 @@ export const isBlockfrostErrorResponse = (
 };
 
 export const handleError = (
-  error: GotError,
+  error: unknown,
 ): BlockfrostServerError | BlockfrostClientError => {
   if (error instanceof HTTPError) {
     let errorInstance: BlockfrostServerError;
@@ -104,9 +104,10 @@ export const handleError = (
 
   // system errors such as -3008 ENOTFOUND and various got errors like ReadError, CacheError, MaxRedirectsError, TimeoutError,...
   // https://github.com/sindresorhus/got/blob/main/documentation/8-errors.md
+
   return new BlockfrostClientError({
-    code: error.code ?? 'ERR_GOT_REQUEST_ERROR', // ENOTFOUND, ETIMEDOUT...
-    message: error.message, // getaddrinfo ENOTFOUND cardano-testnet.blockfrost.io'
-    url: error.request?.requestUrl,
+    code: (error as GotError).code ?? 'ERR_GOT_REQUEST_ERROR', // ENOTFOUND, ETIMEDOUT...
+    message: (error as GotError).message, // getaddrinfo ENOTFOUND cardano-testnet.blockfrost.io'
+    url: (error as GotError).request?.requestUrl,
   });
 };


### PR DESCRIPTION
## Problem

We've wrapped every got request promise with new promise which was rather unnecessary for simple calls (excluding paginated *All variants)

## Solution
For most calls we are able to omit creating additional promise, making code simpler and at the same time exposing got instance directly which could provide additional functionality.