### PR TITLE
feat: add missed query params for governance.dreps and assetsTransactions

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `poolsByIdVotes`, `poolsByIdVotesAll` for retrieving votes cast by a stake pool
 - `blocksTxsCbor`, `blocksTxsCborAll`, `blocksLatestTxsCbor` for retrieving block transactions with their CBOR data
 - `blocksBySlot`, `blocksByEpochAndSlot` for retrieving a specific block by its slot (and epoch)
+- Optional sorting/filtering options (`order_by`, `retired`, `expired`) for `governance.dreps`
+- Optional `from`/`to` block-range filtering for `assetsTransactions`
 
 ### Changed
 

--- a/src/endpoints/api/assets/index.ts
+++ b/src/endpoints/api/assets/index.ts
@@ -126,6 +126,7 @@ export async function assetsHistoryAll(
  *
  * @param asset - Concatenation of the policy ID and hex-encoded asset name
  * @param pagination - Optional, Pagination options
+ * @param cursorPagination - Optional, Additional options such as cursor pagination
  * @returns List of a specific asset transactions.
  *
  */
@@ -133,8 +134,10 @@ export async function assetsTransactions(
   this: BlockFrostAPI,
   asset: string,
   pagination?: PaginationOptions,
+  cursorPagination?: CursorPaginationOptions,
 ): Promise<components['schemas']['asset_transactions']> {
   const paginationOptions = getPaginationOptions(pagination);
+  const cursorPaginationParams = getCursorPaginationParams(cursorPagination);
 
   try {
     const res = await this.instance<
@@ -144,6 +147,8 @@ export async function assetsTransactions(
         page: paginationOptions.page,
         count: paginationOptions.count,
         order: paginationOptions.order,
+        from: cursorPaginationParams.from,
+        to: cursorPaginationParams.to,
       },
     });
     return res.body;

--- a/src/endpoints/api/governance/index.ts
+++ b/src/endpoints/api/governance/index.ts
@@ -1,7 +1,11 @@
 import { getPaginationOptions, paginateMethod } from '../../../utils';
 import { components } from '@blockfrost/openapi';
 import { BlockFrostAPI } from '../../../index';
-import { AllMethodOptions, PaginationOptions } from '../../../types';
+import {
+  AllMethodOptions,
+  DRepsQueryOptions,
+  PaginationOptions,
+} from '../../../types';
 import { handleError } from '../../../utils/errors';
 
 export class GovernanceAPI {
@@ -135,11 +139,13 @@ export class GovernanceAPI {
    * @see {@link https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps | API docs for Delegate Representatives (DReps)}
    *
    * @param pagination - Optional, Pagination options
+   * @param options - Optional, Sorting (`order_by`) and filtering (`retired`, `expired`) options
    * @returns List of registered stake pools.
    *
    */
   async dreps(
     pagination?: PaginationOptions,
+    options?: DRepsQueryOptions,
   ): Promise<components['schemas']['dreps']> {
     const paginationOptions = getPaginationOptions(pagination);
 
@@ -151,6 +157,9 @@ export class GovernanceAPI {
           page: paginationOptions.page,
           count: paginationOptions.count,
           order: paginationOptions.order,
+          order_by: options?.order_by,
+          retired: options?.retired,
+          expired: options?.expired,
         },
       });
       return res.body;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,15 @@ export type CursorPaginationOptions = {
   to?: string | undefined;
 };
 
+export type DRepsQueryOptions = {
+  /** Sort key. Set to `amount` to sort by voting power. When omitted, DReps are ordered by their internal registration order. */
+  order_by?: 'amount' | undefined;
+  /** Filter. When `true`, only returns deregistered DReps; when `false`, only currently registered ones. When omitted, both are returned. */
+  retired?: boolean | undefined;
+  /** Filter. When `true`, only returns DReps inactive longer than the `drep_activity` parameter; when `false`, only non-expired ones. When omitted, both are returned. */
+  expired?: boolean | undefined;
+};
+
 export type AllMethodOptions = {
   batchSize?: number | undefined;
   order?: 'asc' | 'desc';

--- a/test/fixtures/endpoints.ts
+++ b/test/fixtures/endpoints.ts
@@ -364,6 +364,19 @@ export default [
   },
   {
     command: (SDK: BlockFrostAPI) =>
+      SDK.assetsTransactions(
+        '00000002df633853f6a47465c9496721d2d5b1291b8398016c0e87ae6e7574636f696e',
+        { count: 10 },
+        { from: '8929261', to: '9999269:10' },
+      ),
+    endpointMock: [],
+    path: mainnetUrl(
+      '/assets/00000002df633853f6a47465c9496721d2d5b1291b8398016c0e87ae6e7574636f696e/transactions',
+    ),
+    response: [],
+  },
+  {
+    command: (SDK: BlockFrostAPI) =>
       SDK.assetsAddresses(
         '00000002df633853f6a47465c9496721d2d5b1291b8398016c0e87ae6e7574636f696e',
       ),
@@ -1007,6 +1020,34 @@ export default [
   },
   {
     command: (SDK: BlockFrostAPI) => SDK.governance.dreps(),
+    path: mainnetUrl(`governance/dreps`),
+    endpointMock: [
+      {
+        drep_id: 'drep1mvdu8slennngja7w4un6knwezufra70887zuxpprd64jxfveahn',
+        hex: 'db1bc3c3f99ce68977ceaf27ab4dd917123ef9e73f85c304236eab23',
+      },
+      {
+        drep_id: 'drep1cxayn4fgy27yaucvhamsvqj3v6835mh3tjjx6x8hdnr4',
+        hex: 'c1ba49d52822bc4ef30cbf77060251668f1a6ef15ca46d18f76cc758',
+      },
+    ],
+    response: [
+      {
+        drep_id: 'drep1mvdu8slennngja7w4un6knwezufra70887zuxpprd64jxfveahn',
+        hex: 'db1bc3c3f99ce68977ceaf27ab4dd917123ef9e73f85c304236eab23',
+      },
+      {
+        drep_id: 'drep1cxayn4fgy27yaucvhamsvqj3v6835mh3tjjx6x8hdnr4',
+        hex: 'c1ba49d52822bc4ef30cbf77060251668f1a6ef15ca46d18f76cc758',
+      },
+    ],
+  },
+  {
+    command: (SDK: BlockFrostAPI) =>
+      SDK.governance.dreps(
+        { page: 1, order: 'desc' },
+        { order_by: 'amount', retired: false, expired: false },
+      ),
     path: mainnetUrl(`governance/dreps`),
     endpointMock: [
       {


### PR DESCRIPTION
## Summary

Follow-up to #313. Two query-parameter additions from the OpenAPI 0.1.86→0.1.92 range were not covered there because the SDK forwards search params explicitly. Intended for the unreleased 6.2.0, so no version bump.

### `governance.dreps` sorting/filtering (OpenAPI 0.1.89)

`dreps()` accepts an optional second argument (`DRepsQueryOptions`) forwarding `order_by`, `retired` and `expired`:

```ts
await API.governance.dreps(
  { page: 1, order: 'desc' },
  { order_by: 'amount', retired: false, expired: false },
);
```

This restores the change from #312 that was dropped when #313 superseded it.

### `assetsTransactions` block-range filtering (OpenAPI 0.1.91)

`assetsTransactions()` accepts an optional third argument (`CursorPaginationOptions`) forwarding `from`/`to`, matching the existing `addressesTransactions` and `assetsUtxos` signatures.

## Test plan

- [x] New fixtures exercising both new signatures; full vitest suite passes
- [x] `yarn type-check`, `yarn lint`, `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
